### PR TITLE
fixed start_sonar func which only started sonar.service if it was alr…

### DIFF
--- a/tools/update.sh
+++ b/tools/update.sh
@@ -83,8 +83,13 @@ function stop_sonar {
 }
 
 function start_sonar {
-    if [ "$(sudo systemctl is-active sonar.service)" = "active" ]; then
+    if [ "$(sudo systemctl is-active sonar.service)" = "inactive" ]; then
         sudo systemctl start sonar.service &> /dev/null
+    else
+        if [ "$(sudo systemctl is-active sonar.service)" != "active" ]; then
+            echo “sonar.service could not be started”
+            echo “Try running \"sudo systemctl start sonar.service\" manually”
+        fi
     fi
 }
 


### PR DESCRIPTION
The start_sonar function inside tools/update.sh checked if the sonar.service is "active" before starting it which is pointless. Thought I'd fix that for you guys. I made it check "inactive" (instead of "active" like before) if that returns false, then it checks if the service is not already active. If it's not active, it fails softly and tells the user to restart the service manually. 

Best,
Anders R.