### PR TITLE
fix: add symlink check to create_filestructure()

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -113,6 +113,7 @@ import_config() {
 create_filestructure() {
     for i in "${SONAR_CONFIG_PATH}" "${SONAR_LOG_PATH%/*.*}"; do
         if [[ ! -d "${i}" ]] && [[ ! -L "${i}" ]]; then
+            sudo -u "${BASE_USER}" \
             mkdir -p "${i}"
         fi
     done

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -112,7 +112,7 @@ import_config() {
 
 create_filestructure() {
     for i in "${SONAR_CONFIG_PATH}" "${SONAR_LOG_PATH%/*.*}"; do
-        if [[ ! -d "${i}" ]]; then
+        if [[ ! -d "${i}" ]] && [[ ! -L "${i}" ]]; then
             mkdir -p "${i}"
         fi
     done


### PR DESCRIPTION
since a common use is to symlinking a a config folder in order to backup it in many ways like git. I've added [[ ! -L "${i}" ]] - symlink check to create_filestructure() it will check if dir is missing or if it's not a symlink before trying to execute mkdir -p.  since your only check was to check if its a Dir your install fails on mkdir -p since its already exists as symlink at my case.