### PR TITLE
fix: restart service if no gateway is found

### DIFF
--- a/libs/core.sh
+++ b/libs/core.sh
@@ -108,6 +108,15 @@ function get_def_gw {
     if [ "$(cat /sys/class/net/wlan0/operstate)" == "up" ]; then
         default_gw="$(ip route | awk 'NR==1 {print $3}')"
         echo "${default_gw}"
+        if [ -z "$default_gw" ]; then
+            log_msg "WARN: Cannot get the default gateway. Restarting service..."
+            sleep 5
+            systemctl restart sonar.service
+        fi
+    else
+        log_msg "WARN: Network is not ready yet. Restarting service..."
+        sleep 5
+        systemctl restart sonar.service
     fi
 }
 


### PR DESCRIPTION
Fixes issue reported in #12.

Previously if the network was not `up` or `ip route` failed to provide the expected output, the variable `SONAR_TARGET` was empty.

Now, if any of the two checks fail, sonar waits for a few seconds and then restarts the service.  
Hopefully the network will be ready on the next attempt.

Tested on my Raspberry Pi, running MainsailOS, and indeed the behaviour is the expected.  
I can see in the logs that sonar restarts shortly after boot, and then remains functional.  
I don't get WiFi restarts any more.