### PR TITLE
fix: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ How often should be pinged?
 
 Sets interval in seconds, how long it should wait for next connection check.
 
-    restart_treshold: 10
+    restart_threshold: 10
 
 The last option is a delay, in seconds, between shutdown WiFi Interface and bring it up again.
 

--- a/libs/core.sh
+++ b/libs/core.sh
@@ -131,12 +131,15 @@ function setup_env {
     fi
     SONAR_PING_COUNT="$(get_param sonar count)"
     SONAR_CHECK_INTERVAL="$(get_param sonar interval)"
-    SONAR_RESTART_TRESHOLD="$(get_param sonar restart_treshold)"
+    SONAR_RESTART_THRESHOLD="$(get_param sonar restart_threshold)"
+    if [[ -z "${SONAR_RESTART_THRESHOLD}" ]]; then
+        SONAR_RESTART_THRESHOLD="$(get_param sonar restart_treshold)"
+    fi
     SONAR_DEBUG_LOG="$(get_param sonar debug_log)"
     declare -r SONAR_TARGET
     declare -r SONAR_PING_COUNT
     declare -r SONAR_CHECK_INTERVAL
-    declare -r SONAR_RESTART_TRESHOLD
+    declare -r SONAR_RESTART_THRESHOLD
     declare -r SONAR_DEBUG_LOG
 
     # Set vars only once!
@@ -216,8 +219,8 @@ function keepalive {
         fi
     else
         log_msg "Connection lost, ${SONAR_TARGET} not reachable!"
-        log_msg "Restarting network in ${SONAR_RESTART_TRESHOLD:-10} seconds."
-        sleep "${SONAR_RESTART_TRESHOLD:-10}"
+        log_msg "Restarting network in ${SONAR_RESTART_THRESHOLD:-10} seconds."
+        sleep "${SONAR_RESTART_THRESHOLD:-10}"
         until ping -c1 "${SONAR_TARGET}" > /dev/null; do
             used_retries=$((used_retries+1))
             retry_count=$((retry_count+1))

--- a/resources/sonar.conf
+++ b/resources/sonar.conf
@@ -14,4 +14,4 @@ persistant_log: false       # If true logs in /var/log/sonar.log, false logs to 
 target: auto                # IP Address, URL or auto as ping target
 count: 3                    # How often should be pinged?
 interval: 60                # Ping again after X seconds
-restart_treshold: 10        # If failed, restart WiFi after X seconds
+restart_threshold: 10        # If failed, restart WiFi after X seconds

--- a/resources/sonar.conf
+++ b/resources/sonar.conf
@@ -14,4 +14,4 @@ persistant_log: false       # If true logs in /var/log/sonar.log, false logs to 
 target: auto                # IP Address, URL or auto as ping target
 count: 3                    # How often should be pinged?
 interval: 60                # Ping again after X seconds
-restart_threshold: 10        # If failed, restart WiFi after X seconds
+restart_threshold: 10       # If failed, restart WiFi after X seconds


### PR DESCRIPTION
This fixes the typo of `restart_treshold` and corrects it to `restart_threshold`.
For backwards compatibility it will check inside the config for the typoed `restart_treshold` too.

Signed-off-by: Patrick Gehrsitz <mryel00.github@gmail.com>