### PR TITLE
feat: wait for any wlan interface to be up before getting default gw

### DIFF
--- a/libs/core.sh
+++ b/libs/core.sh
@@ -105,7 +105,7 @@ function check_eth_con {
 # get default gw
 function get_def_gw {
     local default_gw
-    if [ "$(cat /sys/class/net/wlan0/operstate)" == "up" ]; then
+    if [ "$(cat /sys/class/net/wlan*/operstate | grep 'up' -m 1)" == "up" ]; then
         default_gw="$(ip route | awk 'NR==1 {print $3}')"
         echo "${default_gw}"
         if [ -z "${default_gw}" ]; then


### PR DESCRIPTION
On my raspberry pi, I have disabled the built-in wifi and use a usb wifi adapter for better wifi signal. This results `/sys/class/net/wlan0/operstate` always being down. The workaround is to not use `auto` as the target and specify my gateway manually. In my case `/sys/class/net/wlan1/operstate` is the one that will be `up` when I am connected. This pull request will look for any `wlan*` interface to be `up`. Then it can proceed to get the default gateway from `ip route` (which still works as-is since there is nothing interface specific there).