### PR TITLE
fix: fix conditions for add_update_entry function

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -290,8 +290,7 @@ main() {
     install_logrotate
 
     ## Step 7: Add moonraker update_manager entry
-    if [[ "${SONAR_UNATTENDED}" = "1" ]] ||
-    [[ "${SONAR_ADD_SONAR_MOONRAKER}" = "1" ]]; then
+    if [[ "${SONAR_ADD_SONAR_MOONRAKER}" = "1" ]]; then
         add_update_entry
     fi
 


### PR DESCRIPTION
This PR only remove the condition `"${SONAR_UNATTENDED}" = "1"` for `add_update_entry`.