### PR TITLE
Confirm outages with a TCP probe before restarting WiFi

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ Sets interval in seconds, how long it should wait for next connection check.
 
 Delay in seconds before attempting WiFi restart after connection loss
 
+    tcp_fallback: true
+
+When the ICMP ping fails, confirm the outage with a TCP connection before
+restarting WiFi. Some networks (most notably iOS/Android personal hotspots)
+silently drop ICMP while TCP keeps working — without this check, sonar would
+tear down a perfectly working connection. An outage is declared only when both
+the ICMP ping and the TCP probe fail. Set to `false` to use ICMP only.
+
+    tcp_check_host: 1.1.1.1
+    tcp_check_port: 443
+
+Host and port used for the TCP connectivity probe described above.
+
 ---
 
 That's it. It isn't the best method to keep your WiFi up and running, but it is

--- a/resources/sonar.conf
+++ b/resources/sonar.conf
@@ -18,5 +18,5 @@ count: 3                    # Number of pings per check
 interval: 60                # Seconds between ping checks
 restart_threshold: 10       # Delay in seconds before attempting WiFi restart after connection loss
 tcp_fallback: true          # If ICMP fails, confirm with a TCP probe before declaring an outage (true/false)
-tcp_check_host: 1.1.1.1     # Host for the TCP connectivity probe
+tcp_check_host: 1.1.1.1     # IP address for the TCP connectivity probe (use an IP, not a hostname, to avoid DNS false positives)
 tcp_check_port: 443         # Port for the TCP connectivity probe

--- a/resources/sonar.conf
+++ b/resources/sonar.conf
@@ -17,3 +17,6 @@ target: auto                # Target IP address to ping, or 'auto' for automatic
 count: 3                    # Number of pings per check
 interval: 60                # Seconds between ping checks
 restart_threshold: 10       # Delay in seconds before attempting WiFi restart after connection loss
+tcp_fallback: true          # If ICMP fails, confirm with a TCP probe before declaring an outage (true/false)
+tcp_check_host: 1.1.1.1     # Host for the TCP connectivity probe
+tcp_check_port: 443         # Port for the TCP connectivity probe

--- a/sonar.py
+++ b/sonar.py
@@ -131,6 +131,12 @@ class SonarDaemon:
             'tcp_check_port': cp.getint('sonar', 'tcp_check_port')
         }
 
+        port = self.config['tcp_check_port']
+        if not 1 <= port <= 65535:
+            self.logger.warning(f"tcp_check_port {port} is out of range"
+                                f" (1-65535), falling back to 443.")
+            self.config['tcp_check_port'] = 443
+
     def _is_service_active(self, service_name):
         try:
             result = subprocess.run(["systemctl", "is-active", service_name],
@@ -224,7 +230,8 @@ class SonarDaemon:
         try:
             with socket.create_connection((host, int(port)), timeout=timeout):
                 return True
-        except OSError:
+        except (OSError, ValueError, OverflowError) as e:
+            self.logger.debug(f"tcp_check {host}:{port} failed: {e}")
             return False
 
     def is_reachable(self, target):

--- a/sonar.py
+++ b/sonar.py
@@ -33,6 +33,7 @@ import os
 import re
 import sys
 import shutil
+import socket
 import logging
 
 
@@ -81,6 +82,9 @@ class SonarDaemon:
         self.logger.info(f"  count: {self.config['count']}")
         self.logger.info(f"  interval: {self.config['interval']}")
         self.logger.info(f"  restart_threshold: {self.config['restart_threshold']}")
+        self.logger.info(f"  tcp_fallback: {self.config['tcp_fallback']}")
+        self.logger.info(f"  tcp_check_host: {self.config['tcp_check_host']}")
+        self.logger.info(f"  tcp_check_port: {self.config['tcp_check_port']}")
 
         # Set debug level if needed
         if self.config['debug_log']:
@@ -105,7 +109,10 @@ class SonarDaemon:
             'target': 'auto',
             'count': '3',
             'interval': '60',
-            'restart_threshold': '10'
+            'restart_threshold': '10',
+            'tcp_fallback': 'true',
+            'tcp_check_host': '1.1.1.1',
+            'tcp_check_port': '443'
         }
 
         if not cp.has_section('sonar'):
@@ -118,7 +125,10 @@ class SonarDaemon:
             'target': cp.get('sonar', 'target'),
             'count': cp.getint('sonar', 'count'),
             'interval': cp.getint('sonar', 'interval'),
-            'restart_threshold': cp.getint('sonar', 'restart_threshold')
+            'restart_threshold': cp.getint('sonar', 'restart_threshold'),
+            'tcp_fallback': cp.getboolean('sonar', 'tcp_fallback'),
+            'tcp_check_host': cp.get('sonar', 'tcp_check_host'),
+            'tcp_check_port': cp.getint('sonar', 'tcp_check_port')
         }
 
     def _is_service_active(self, service_name):
@@ -209,6 +219,37 @@ class SonarDaemon:
             self.logger.error(f"Error executing ping: {e}")
             return False
 
+    def tcp_check(self, host, port, timeout=3):
+        """Return True if a TCP connection to host:port can be established."""
+        try:
+            with socket.create_connection((host, int(port)), timeout=timeout):
+                return True
+        except OSError:
+            return False
+
+    def is_reachable(self, target):
+        """Decide whether connectivity is up, robust to ICMP-filtered networks.
+
+        Some networks — most notably iOS/Android personal hotspots — silently
+        drop ICMP, so a failed ping does NOT mean the link is down. Restarting
+        WiFi there would tear down a perfectly working connection. Fall back to
+        a real TCP connection before declaring an outage: only when BOTH ICMP
+        and TCP fail is the network considered actually down.
+        """
+        if self.ping_target(target, self.config['count']):
+            return True
+
+        if self.config['tcp_fallback']:
+            host = self.config['tcp_check_host']
+            port = self.config['tcp_check_port']
+            if self.tcp_check(host, port):
+                self.logger.debug(f"ICMP to {target} failed but TCP "
+                                  f"{host}:{port} succeeded — link is up "
+                                  f"(ICMP filtered). Not an outage.")
+                return True
+
+        return False
+
     def run(self):
         if not self.config['enable']:
             self.logger.info("Sonar is disabled in the configuration. Exiting.")
@@ -233,7 +274,7 @@ class SonarDaemon:
             if target == "auto":
                 target = gateway['gateway']
 
-            if not self.ping_target(target, self.config['count']):
+            if not self.is_reachable(target):
                 restart_threshold = self.config['restart_threshold']
                 self.logger.info(f"Connection lost – {target} is unreachable!")
                 self.logger.info(f"Waiting {restart_threshold} seconds before"
@@ -242,8 +283,8 @@ class SonarDaemon:
 
                 retry_count = 0
                 used_retries = 0
-                # Repeat until a single ping is successful
-                while not self.ping_target(target, 1):
+                # Repeat until connectivity is restored (ICMP or TCP)
+                while not self.is_reachable(target):
                     retry_count += 1
                     used_retries += 1
                     self.restart_wifi(gateway['interface'])


### PR DESCRIPTION
## Problem

Sonar decides a connection is down purely from ICMP ping failure (`ping_target`). On networks that silently drop ICMP — most notably iOS and Android personal hotspots — the ping always fails even though the link is perfectly fine (association, DHCP, TCP and HTTP all succeed). Sonar then concludes the connection is lost and restarts WiFi in a loop, tearing down a working connection.

It is easy to reproduce: tether a device to an iPhone Personal Hotspot and run sonar with `target: auto`. The gateway never answers ICMP, so sonar restarts the network every cycle.

## Change

Add an optional TCP fallback. When the ICMP ping fails, sonar tries to open a real TCP connection (default `1.1.1.1:443`) before declaring an outage. An outage is reported only when **both** the ICMP ping and the TCP probe fail. The check is used by both the initial detection and the reconnect loop, so a hotspot-connected device no longer flaps.

New config options (all optional, sensible defaults, fully backward compatible):

- `tcp_fallback` (default `true`) — enable/disable the probe
- `tcp_check_host` (default `1.1.1.1`)
- `tcp_check_port` (default `443`)

Set `tcp_fallback: false` to keep the previous ICMP-only behaviour.

## Notes

- No new dependencies (uses `socket` from the stdlib).
- README and `resources/sonar.conf` updated to document the options.
- Tested on a Raspberry Pi tethered to an iPhone hotspot: ICMP to the gateway fails, TCP to `1.1.1.1:443` succeeds, sonar correctly stays quiet and the connection is preserved.
